### PR TITLE
Add gh-aw workflow source for fitness-review

### DIFF
--- a/workflows/fitness-review.md
+++ b/workflows/fitness-review.md
@@ -1,0 +1,202 @@
+---
+description: |
+  Runs a full project fitness review across architecture, security, reliability,
+  testing, performance, algorithms, data, accessibility, process, and maintainability.
+  Produces a scored report with file:line evidence and prioritized action items,
+  filed as a GitHub issue.
+
+on:
+  schedule: weekly
+  workflow_dispatch:
+
+timeout-minutes: 30
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+network: defaults
+
+tools:
+  github:
+    toolsets: [context, repos, issues, pull_requests]
+    lockdown: true
+
+safe-outputs:
+  mentions: false
+  allowed-github-references: []
+  create-issue:
+    max: 1
+    title-prefix: "[fitness-report] "
+    labels: [report, fitness-review, automation]
+    close-older-issues: true
+---
+
+# Project Fitness Review
+
+Analyze this repository and produce a comprehensive fitness report. Create a GitHub issue with your findings using the create_issue tool.
+
+## Scope
+
+Review the entire codebase unless the user specifies otherwise. If there are pending git changes, focus on those. Identify the architecture type (monolith, microservices, layered) and adapt the review depth accordingly.
+
+## Review Domains
+
+Evaluate each domain below. Score each dimension from 1–10 with file:line evidence. Skip domains that do not apply (e.g., skip accessibility if no frontend; skip data if no database).
+
+### 1. Architecture
+
+- Coupling (cross-boundary imports, abstractions at boundaries)
+- Cohesion (single responsibility, related content per module)
+- Layering (presentation, business logic, data access)
+- Modularity (clear boundaries, minimal skip-layer violations)
+- Naming (clarity, consistency, discoverability)
+- API design (consistency, error handling, versioning)
+- Maintainability (code smells, god classes, duplication)
+
+### 2. Security
+
+- Input validation and sanitization
+- Authentication and authorization
+- Data protection and sensitive-data handling
+- Dependency vulnerabilities
+- Error handling and logging (no sensitive data in logs)
+- Cryptography usage
+
+### 3. Reliability
+
+- Observability (logging, metrics, tracing)
+- Availability design
+- Timeout and retry hygiene
+- CI/CD maturity
+- Incident readiness
+- Capacity planning
+- Deploy hygiene
+
+### 4. Testing
+
+- Test pyramid balance
+- Test quality and coverage
+- Performance testing
+- Debugging support
+- CI integration
+
+### 5. Performance
+
+- Algorithmic efficiency
+- Database design
+- Caching strategy
+- Scalability readiness
+- Resource utilization
+- Data pipeline efficiency
+
+### 6. Algorithms
+
+- Algorithm choice for problem domain
+- Data structure selection
+- Complexity (time and space)
+- Concurrency safety
+- Edge cases and correctness
+
+### 7. Data
+
+- Schema design
+- Migration safety
+- Data integrity
+- Query correctness
+- Data modeling
+- Pipeline quality
+
+### 8. Accessibility (skip if no frontend)
+
+- Semantic HTML
+- Keyboard navigation
+- Screen reader support
+- Color and contrast
+- Progressive enhancement
+- Responsive design
+- Usability heuristics
+
+### 9. Process
+
+- Documentation
+- Workflow and branching
+- Code review
+- Dependency management
+- Project organization
+- Portability
+- Leadership signals
+
+### 10. Maintainability
+
+- Structural complexity (cyclomatic, cognitive, LOC, nesting)
+- Understandability (naming, flow clarity, non-obvious logic documentation)
+- Technical debt (TODO/FIXME, duplication, magic numbers, suppressions)
+- Coupling and dependency depth
+- Code smell density (god classes, long methods, feature envy)
+
+## Report Structure
+
+```markdown
+# Project Fitness Report
+
+**Date:** YYYY-MM-DD
+**Scope:** [what was reviewed]
+
+## Overall Score: X.X / 10
+
+| Domain | Score | Status |
+|--------|-------|--------|
+| Architecture | X/10 | ✅/⚠️/❌ |
+| Security | X/10 | ✅/⚠️/❌ |
+| ... |
+
+Status: 8–10 = ✅ Healthy, 5–7 = ⚠️ Needs Attention, 1–4 = ❌ Critical
+
+## Top 10 Action Items (Priority Order)
+
+1. [CRITICAL] description — file:line
+2. [HIGH] description — file:line
+...
+
+## Domain Details
+
+[Per-domain scores, evidence, and findings]
+
+## References
+
+Based on guidance from https://jeffbailey.us/categories/fundamentals/
+```
+
+## Scoring
+
+Overall score = weighted average:
+
+- Architecture: 14%
+- Security: 14%
+- Reliability: 10%
+- Testing: 10%
+- Performance: 10%
+- Algorithms: 10%
+- Data: 10% (0% if skipped)
+- Accessibility: 8% (0% if skipped)
+- Process: 8%
+- Maintainability: 6%
+
+If a domain is skipped, redistribute its weight proportionally.
+
+## Action Item Prioritization
+
+1. **CRITICAL** — Security vulnerabilities, data loss risks, production outages
+2. **HIGH** — Architecture violations, missing tests for critical paths, algorithm correctness, data integrity gaps
+3. **MEDIUM** — Performance bottlenecks, observability gaps, process improvements, concurrency risks
+4. **LOW** — Style, naming, nice-to-haves
+
+## Process
+
+1. Map the codebase structure (directories, entry points, dependencies)
+2. Analyze each domain systematically
+3. Assign scores with evidence
+4. Rank action items by severity
+5. Create a GitHub issue with the unified report using the create_issue tool


### PR DESCRIPTION
## Summary

- `SETUP.md` documents `gh aw add jeffabailey/skills/fitness-review` but this fails with a 404 because `gh aw add` looks for `workflows/fitness-review.md` and the file doesn't exist
- Adds `workflows/fitness-review.md` — the gh-aw workflow source file that compiles to the equivalent of `.github/workflows/fitness-review.yml`
- Prompt content is inlined from `.github/fitness-review-prompt.md`

## Test plan

- [x] `gh aw compile workflows/fitness-review.md` succeeds (0 errors, 0 warnings)
- [x] `gh aw compile workflows/fitness-review.md --engine claude` succeeds
- [x] `gh aw add <local-path>/workflows/fitness-review.md` successfully adds the workflow to a test repo
- [ ] `gh aw add jeffabailey/skills/fitness-review` works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)