### PR TITLE
fix(ci): add Internal link check job to satisfy required status check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -103,4 +103,21 @@ jobs:
           python-version: "3.12"
       - name: Run engine-config unit tests
         run: python3 -m unittest tests/test_engine_config.py -v
+
+  internal-link-check:
+    name: Internal link check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Check internal (relative) markdown links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          # --offline checks only local/relative links (no network) — this is a
+          # required status check, so keep it secret-free and deterministic.
+          # Exclude src/*/references/wisdom.md: those are machine-synced blog
+          # exports whose Hugo cover-images (*.png) and site-absolute /blog/...
+          # links are not repo-internal and would false-fail every sync PR.
+          args: --offline --no-progress --exclude-path 'wisdom.md' './**/*.md'
+          fail: true
         


### PR DESCRIPTION
## Problem

PR #50 (and every PR) is stuck on `Internal link check — Expected — Waiting for status to be reported`, blocking merge even though all real checks pass.

## Root cause

`main` branch protection lists **6** required status contexts, but `.github/workflows/pr-checks.yml` only produces **5**. The 6th — `Internal link check` — is an **orphaned required check**: no workflow or script anywhere posts that context, so GitHub waits for it indefinitely. Same class of defect as the earlier orphaned gh-aw check removed in `281a033`.

## Fix

Add an `internal-link-check` job named exactly `Internal link check` to `pr-checks.yml`. It runs [lychee](https://github.com/lycheeverse/lychee-action) in `--offline` mode (relative/local links only — no secrets, deterministic) over the repo's hand-authored markdown.

`src/*/references/wisdom.md` is excluded: those are machine-synced blog exports whose Hugo cover-image (`*.png`) and site-absolute (`/blog/...`) links are not repo-internal and would false-fail every wisdom sync PR.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` → YAML valid; job name matches the required context exactly
- `lychee --offline --no-progress --exclude-path 'wisdom.md' './**/*.md'` → exit 0 (0 errors across ~30 hand-authored files)
- `bash tests/workflow-tests.sh` → 43 passed, 0 failed

## Notes

This PR's own branch contains the new job, so `Internal link check` runs and reports here — self-unblocking. After it merges, **PR #50 must update its branch with `main`** (branch protection has `strict: true`) to pick up the job and clear its own stuck check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)